### PR TITLE
Fix statusLabel error when launching OCR

### DIFF
--- a/neurocurator/mainWin.py
+++ b/neurocurator/mainWin.py
@@ -1072,7 +1072,7 @@ class Window(QMainWindow):
     def waitForOCR(self, paperId, notify):
         
         while(not self.restClient.checkOCRFinished(paperId, self.dbPath)):
-            self.statusBar().showMessage("Performing OCR...", 10*1000)
+            self.statusBar().showMessage("Performing OCR...")
             time.sleep(5)          
         
         self.statusBar().showMessage("OCR finished.", 10*1000)

--- a/neurocurator/mainWin.py
+++ b/neurocurator/mainWin.py
@@ -1081,10 +1081,10 @@ class Window(QMainWindow):
     def waitForOCR(self, paperId, notify):
         
         while(not self.restClient.checkOCRFinished(paperId, self.dbPath)):
-            self.window.statusLabel.setText("Performing OCR...")
+            self.statusBar().showMessage("Performing OCR...")
             time.sleep(5)          
         
-        self.window.statusLabel.setText("OCR finished.")
+        self.statusBar().showMessage("OCR finished.")
         if notify == QMessageBox.Yes:
             msgBox = QMessageBox()
             msgBox.setStandardButtons(QMessageBox.Cancel)

--- a/neurocurator/mainWin.py
+++ b/neurocurator/mainWin.py
@@ -74,11 +74,6 @@ class Window(QMainWindow):
 
         self.needSavingDisabled = False
 
-        # FIXME Delayed refactoring. Use signals/slots to update the message.
-        self._statusBar = self.statusBar()
-        self.statusLabel = QLabel("")
-        self._statusBar.addWidget(self.statusLabel)
-
         # Get the system username. It will be used to identify the curator
         # in the annotations.
         self.username = getpass.getuser()
@@ -1065,8 +1060,6 @@ class Window(QMainWindow):
                 if not persistId in selectedTags:
                     unusedPersistedSuggestedTags.append(persistId)
 
-
-
             for id in unusedPersistedSuggestedTags + tagIds:    
                 self.addSuggestedTagFromId(id)
 
@@ -1074,17 +1067,15 @@ class Window(QMainWindow):
     def clearPaper(self):
         #self.refEdt.setText("")
         self.IdTxt.setText("")
+
         
-
-
-
     def waitForOCR(self, paperId, notify):
         
         while(not self.restClient.checkOCRFinished(paperId, self.dbPath)):
-            self.statusBar().showMessage("Performing OCR...")
+            self.statusBar().showMessage("Performing OCR...", 10*1000)
             time.sleep(5)          
         
-        self.statusBar().showMessage("OCR finished.")
+        self.statusBar().showMessage("OCR finished.", 10*1000)
         if notify == QMessageBox.Yes:
             msgBox = QMessageBox()
             msgBox.setStandardButtons(QMessageBox.Cancel)


### PR DESCRIPTION
Fix the following error message that was happening when launching OCR:

Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/oreilly/.local/lib/python3.6/site-packages/neurocurator/mainWin.py", line 1084, in waitForOCR
    self.window.statusLabel.setText("Performing OCR...")
AttributeError: 'builtin_function_or_method' object has no attribute 'statusLabel'